### PR TITLE
0.0.1a2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 - Updated app reset flows to stop after repair/reinstall instead of continuing with configuration cleanup
 - Added `reset_license` to preserve MOFA's license-only reset workflow alongside `reset_credentials`
 - Added `reset_teams_force` to provide a Teams force-reinstall path within the unified operation model
-- Updated Teams reset to preserve custom backgrounds, reset Teams TCC state, and reopen Screen Recording settings in interactive modes
+- Updated Teams reset to preserve custom backgrounds, reset Teams TCC state in the logged-in user context, preserve installed app bundles outside force-reinstall mode, and reopen Screen Recording settings in interactive modes
 - Expanded AutoUpdate registration to include current Teams, Edge channels, and Defender ATP when present
 - Fixed Microsoft package header parsing so `reset_teams_force` can validate CDN downloads correctly
 - Updated progress bar behavior so a running operation no longer appears complete before it finishes

--- a/Microsoft-365-Reset.zsh
+++ b/Microsoft-365-Reset.zsh
@@ -1753,12 +1753,14 @@ function resetTeamsOperation() {
     local teamsAppPath="/Applications/Microsoft Teams.app"
     local classicTeamsPath="/Applications/Microsoft Teams classic.app"
     local workOrSchoolTeamsPath="/Applications/Microsoft Teams (work or school).app"
+    local teamsPkgURL="https://go.microsoft.com/fwlink/?linkid=2249065"
     local classicBackgroundsPath="${loggedInUserHome}/Library/Application Support/Microsoft/Teams/Backgrounds"
     local modernBackgroundsPath="${loggedInUserHome}/Library/Containers/com.microsoft.teams2/Data/Library/Application Support/Microsoft/MSTeams/Backgrounds"
     local modernBackgroundsStaging="/tmp/${scriptName}_Teams_Backgrounds"
     local teamsBackgroundArchive="${loggedInUserHome}/Teams_Old_Backgrounds"
     local installAttempt=1
     local installationRetries=5
+    local shouldInstallTeams="false"
     osVersion="$(sw_vers -productVersion)"
 
     pkill -9 'MSTeams' 2>/dev/null
@@ -1776,14 +1778,25 @@ function resetTeamsOperation() {
         if [[ "${forceReinstall}" == "true" ]]; then
             info "Force reinstall requested for Microsoft Teams; removing existing app bundle"
             safeRemove "${teamsAppPath}"
+            shouldInstallTeams="true"
         elif ! is-at-least 23247.0 "${currentTeamsVersion}" && is-at-least 10.15 "${osVersion}"; then
             info "Installed Microsoft Teams is below MOFA minimum; removing for reinstall"
             safeRemove "${teamsAppPath}"
+            shouldInstallTeams="true"
         fi
     fi
 
-    [[ -d "${classicTeamsPath}" ]] && safeRemove "${classicTeamsPath}"
-    [[ -d "${workOrSchoolTeamsPath}" ]] && safeRemove "${workOrSchoolTeamsPath}"
+    if [[ "${forceReinstall}" == "true" && -d "${classicTeamsPath}" ]]; then
+        info "Force reinstall requested for Microsoft Teams; removing classic Teams app bundle"
+        safeRemove "${classicTeamsPath}"
+        shouldInstallTeams="true"
+    fi
+
+    if [[ "${forceReinstall}" == "true" && -d "${workOrSchoolTeamsPath}" ]]; then
+        info "Force reinstall requested for Microsoft Teams; removing Teams work-or-school app bundle"
+        safeRemove "${workOrSchoolTeamsPath}"
+        shouldInstallTeams="true"
+    fi
 
     if [[ -d "${classicBackgroundsPath}" ]]; then
         local originalArchivePath="${teamsBackgroundArchive}"
@@ -1849,7 +1862,9 @@ function resetTeamsOperation() {
     safeRemove "${TMPDIR}/v8-compile-cache-501"
 
     safeRemove "/Library/Logs/Microsoft/Teams"
-    /usr/bin/tccutil reset All com.microsoft.teams2 >>"${scriptLog}" 2>&1
+    if ! runAsUser "${loggedInUser}" /usr/bin/tccutil reset All com.microsoft.teams2 >>"${scriptLog}" 2>&1; then
+        warning "Unable to reset Teams TCC state for ${loggedInUser}"
+    fi
 
     ensureLoginKeychainPresent "${loggedInUser}" "${loggedInUserHome}"
 
@@ -1872,14 +1887,15 @@ function resetTeamsOperation() {
         if [[ $? -ne 0 ]]; then
             warning "Microsoft Teams app bundle damaged; reinstalling"
             safeRemove "${teamsAppPath}"
+            shouldInstallTeams="true"
         else
             info "Microsoft Teams codesign verification passed"
         fi
     fi
 
-    while [[ ! -d "${teamsAppPath}" && ${installAttempt} -le ${installationRetries} ]]; do
+    while [[ "${shouldInstallTeams}" == "true" && ! -d "${teamsAppPath}" && ${installAttempt} -le ${installationRetries} ]]; do
         info "Installing Microsoft Teams (attempt ${installAttempt}/${installationRetries})"
-        repairFromMicrosoftPkg "Microsoft Teams" "https://go.microsoft.com/fwlink/?linkid=2249065" "" || return 1
+        repairFromMicrosoftPkg "Microsoft Teams" "${teamsPkgURL}" "" || return 1
         /usr/bin/codesign -vv --deep "${teamsAppPath}" >>"${scriptLog}" 2>&1
         if [[ $? -eq 0 ]]; then
             local installedTeamsVersion
@@ -1892,7 +1908,7 @@ function resetTeamsOperation() {
         ((installAttempt++))
     done
 
-    if [[ ! -d "${teamsAppPath}" ]]; then
+    if [[ "${shouldInstallTeams}" == "true" && ! -d "${teamsAppPath}" ]]; then
         errorOut "Unable to install a valid Microsoft Teams app bundle"
         return 1
     fi
@@ -2008,6 +2024,7 @@ function op_reset_autoupdate() {
     registerMAUStaticApplicationIfPresent "/Applications/Microsoft Remote Desktop.app" "{ 'Application ID' = 'MSRD10'; LCID = 1033 ; }"
     registerMAUStaticApplicationIfPresent "/Applications/Skype For Business.app" "{ 'Application ID' = 'MSFB16'; LCID = 1033 ; }"
     registerMAUStaticApplicationIfPresent "/Applications/Company Portal.app" "{ 'Application ID' = 'IMCP01'; LCID = 1033 ; }"
+    registerMAUStaticApplicationIfPresent "/Applications/Microsoft Defender.app" "{ 'Application ID' = 'WDAV00'; LCID = 1033 ; }"
     registerMAUStaticApplicationIfPresent "/Applications/Microsoft Defender ATP.app" "{ 'Application ID' = 'WDAV00'; LCID = 1033 ; }"
 
     return 0

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ The script consolidates expanded package workflows into one root-run tool with:
 - `reset_factory` performs its own MOFA-style suite cleanup in addition to dependency expansion
 - App repair/reinstall flows for Word, Excel, PowerPoint, Outlook, and OneNote now stop after repair instead of continuing with configuration cleanup in the same run
 - `reset_teams` preserves Teams backgrounds, resets Teams TCC state, and opens Screen Recording settings in interactive modes
+- `reset_teams` preserves installed Teams app bundles unless repair is required; `reset_teams_force` performs the explicit app removal and reinstall path
 - Teams reset and AutoUpdate registration now treat new Teams as the current `TEAMS21` product while keeping classic Teams on the legacy product ID
 - Separate `reset_license` and `reset_credentials` operations cover MOFA's split between license-only and broader sign-in reset flows
 - `reset_teams_force` provides a force-reinstall path for Teams without adding a new CLI parameter
@@ -100,7 +101,7 @@ Use these IDs in `--operations` CSV:
 | `reset_onenote` | OneNote repair checks + container/group cleanup |
 | `remove_onenote_data` | Remove OneNote cached local data |
 | `reset_onedrive` | OneDrive repair checks + cache/container/keychain cleanup |
-| `reset_teams` | Teams classic/new checks + Teams cache/container/keychain cleanup |
+| `reset_teams` | Teams reset with app validation/repair when needed + Teams cache/container/keychain cleanup |
 | `reset_teams_force` | Force-remove and reinstall Teams, then perform Teams cache/container/keychain cleanup |
 | `reset_autoupdate` | Reset MAU prefs/cache and reinstall/update MAU when applicable |
 | `reset_license` | Reset Office licensing files and core Office identity data |
@@ -153,6 +154,7 @@ The following operations include app repair checks and may download/reinstall fr
 - `reset_onenote`
 - `reset_onedrive`
 - `reset_teams`
+- `reset_teams_force`
 - `reset_autoupdate`
 
 Repair pipeline includes:


### PR DESCRIPTION
Align reset and removal behavior with MOFA community-maintained scripts.

Add reset_license and reset_teams_force operations. Preserve MOFA-style app repair early-exit behavior. Expand Teams and AutoUpdate reset coverage, including TEAMS21 MAU registration. Fix Teams package header parsing and progress dialog behavior. Update README and changelog for 0.0.1a2.