### PR TITLE
1.0.0b3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ Icon?
 .zcompdump*
 .zcompcache/
 *.zwc
+.envrc
 
 ### Local deployment helper artifacts
 /.deployMicrosoft365Reset.zsh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ Guidance for coding agents working in this repository.
 
 - Project: Microsoft 365 Reset
 - Primary artifact: `Microsoft-365-Reset.zsh`
-- Package-era behavior reference: `Resources/Microsoft_Office_Reset_2.0.0b1_expanded/`
+- Package-era behavior reference: `Resources/Microsoft_Office_Reset_2.0.0b1_expanded/` when available locally
 - Primary docs: `README.md` and `CHANGELOG.md`
 
 ## Mission
@@ -43,6 +43,7 @@ Microsoft 365 Reset should provide a safe, clear, swiftDialog-driven workflow to
 
 - Prefer MOFA behavior over package-era behavior by default.
 - Use the package-era reference as secondary context unless MOFA does not cover the behavior in question.
+- Treat package-era report coverage in `scripts/mofa-consult.zsh` as optional maintainer context when the local expanded package reference is unavailable.
 - Keep any divergence from MOFA only when there is a defensible product, safety, platform, or workflow reason.
 - When diverging from MOFA, document the reason in `README.md` and call out the parity impact in change notes or review summaries.
 
@@ -52,7 +53,7 @@ Microsoft 365 Reset should provide a safe, clear, swiftDialog-driven workflow to
 - `scripts/mofa-consult.zsh`: maintainer helper for MOFA sync and inclusion reporting
 - `README.md`: usage and behavior documentation
 - `CHANGELOG.md`: release/change history
-- `Resources/Microsoft_Office_Reset_2.0.0b1_expanded/`: original package scripts and Distribution reference
+- `Resources/Microsoft_Office_Reset_2.0.0b1_expanded/`: optional local package-era scripts and Distribution reference used for secondary maintainer comparisons
 - `.gitignore`: ignore rules for expanded package artifacts
 
 ## Scripting Style (Required)
@@ -84,13 +85,15 @@ Maintain the established style of `Microsoft-365-Reset.zsh` unless the user expl
 1. Run `zsh -n` against every modified Zsh file (required).
 2. At minimum, run `zsh -n Microsoft-365-Reset.zsh` after modifying the main script and `zsh -n scripts/mofa-consult.zsh` after modifying the MOFA helper.
 3. Verify behavior-sensitive changes against operation flow (`self-service` and `silent` assumptions).
-4. Update `README.md` when behavior, parameters, or examples change.
-5. Update `CHANGELOG.md` for meaningful user-visible behavior changes.
-6. Do not add new production dependencies without explicit user confirmation.
+4. When changing `scripts/mofa-consult.zsh`, preserve clean report generation both when the package-era expanded reference is present and when it is absent.
+5. Update `README.md` when behavior, parameters, or examples change.
+6. Update `CHANGELOG.md` for meaningful user-visible behavior changes.
+7. Do not add new production dependencies without explicit user confirmation.
 
 ## Change Discipline
 
 - Prefer minimal, targeted edits over broad rewrites.
 - Avoid hidden behavior changes during refactors.
 - If changing operation behavior, call out parity impact explicitly.
+- For maintainer-only reporting changes, prefer warning-and-skip behavior over aborting when optional local reference artifacts are missing.
 - Keep naming, formatting, and copy consistent with existing script patterns.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,11 +32,19 @@ Microsoft 365 Reset should provide a safe, clear, swiftDialog-driven workflow to
 
 ## Implementation Priorities
 
-1. Keep behavior aligned with intended package-era functionality.
-2. Preserve operator and end-user clarity in dialog text and warnings.
-3. Keep changes minimal, targeted, and safe.
-4. Maintain deterministic execution and reliable failure handling.
-5. Keep docs synchronized with script behavior.
+1. Treat current MOFA behavior as the primary parity baseline for reset and removal workflows.
+2. Use the package-era reference to preserve retained chooser logic, dependency relationships, and legacy coverage where MOFA does not provide a current equivalent.
+3. Preserve operator and end-user clarity in dialog text and warnings.
+4. Keep changes minimal, targeted, and safe.
+5. Maintain deterministic execution and reliable failure handling.
+6. Keep docs synchronized with script behavior.
+
+## Behavior Precedence
+
+- Prefer MOFA behavior over package-era behavior by default.
+- Use the package-era reference as secondary context unless MOFA does not cover the behavior in question.
+- Keep any divergence from MOFA only when there is a defensible product, safety, platform, or workflow reason.
+- When diverging from MOFA, document the reason in `README.md` and call out the parity impact in change notes or review summaries.
 
 ## Key Files
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Changelog
 
-### Unreleased
+### Version 1.0.0b3 (06-Apr-2026)
+- Fresh run of `scripts/mofa-consult.zsh` to sync with the latest MOFA stable feed and generate an updated local inclusion report for this repo
+- Modified interactive user cancellations to exit cleanly so Jamf Pro policy logs do not report them as failures.
 
 ### Version 1.0.0b2 (31-Mar-2026)
 - Added `scripts/mofa-consult.zsh` to sync a sibling `../MOFA` checkout from upstream MOFA and generate a local inclusion report for this repo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Version 1.0.0b3 (06-Apr-2026)
 - Fresh run of `scripts/mofa-consult.zsh` to sync with the latest MOFA stable feed and generate an updated local inclusion report for this repo
+- Updated `scripts/mofa-consult.zsh` to skip the package-era comparison section with a warning when the local expanded package reference is unavailable, instead of failing the full report
+- Clarified README maintainer workflow wording around optional package-era coverage and intentional MOFA divergences
 - Modified interactive user cancellations to exit cleanly so Jamf Pro policy logs do not report them as failures.
 
 ### Version 1.0.0b2 (31-Mar-2026)

--- a/Microsoft-365-Reset.zsh
+++ b/Microsoft-365-Reset.zsh
@@ -14,8 +14,9 @@
 #
 # HISTORY
 #
-# Version 1.0.0b2, 31-Mar-2026, Dan K. Snelson (@dan-snelson)
-#  - Align Outlook primary repair URL with current MOFA stable feed
+# Version 1.0.0b3, 06-Apr-2026, Dan K. Snelson (@dan-snelson)
+#  - Fresh run of `scripts/mofa-consult.zsh` to sync with the latest MOFA stable feed and generate an updated local inclusion report for this repo
+#  - Modified interactive user cancellations to exit cleanly so Jamf Pro policy logs do not report them as failures.
 #
 ####################################################################################################
 
@@ -31,7 +32,7 @@ export PATH=/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin/
 setopt NONOMATCH
 
 # Script identity
-scriptVersion="1.0.0b2"
+scriptVersion="1.0.0b3"
 humanReadableScriptName="Microsoft 365 Reset"
 scriptName="M365R"
 
@@ -124,6 +125,7 @@ resolvedOperations=()
 failedOperations=()
 completedOperations=()
 dialogPID=""
+interactiveCancelReturnCode="30"
 
 # Logged-in user context (resolved during preflight)
 loggedInUser=""
@@ -646,7 +648,7 @@ function maybeRepairOfficeApp() {
     fi
 
     if [[ "${repairPerformed}" == "true" ]]; then
-        info "${appName} repair completed; skipping configuration cleanup to match MOFA behavior"
+        info "${appName} repair completed; skipping configuration cleanup for this run as a documented divergence from MOFA"
         return 2
     fi
 
@@ -742,8 +744,10 @@ function showIntroDialog() {
     local rc=$?
     if [[ ${rc} -ne 0 ]]; then
         info "User '${loggedInUser}' cancelled intro dialog"
-        exit 2
+        return "${interactiveCancelReturnCode}"
     fi
+
+    return 0
 }
 
 function parseOperationCSV() {
@@ -824,7 +828,7 @@ function showSelectionDialog() {
         rc=$?
         if [[ ${rc} -ne 0 ]]; then
             info "User '${loggedInUser}' cancelled selection dialog"
-            exit 2
+            return "${interactiveCancelReturnCode}"
         fi
 
         parseDialogSelections "${dialogOutput}"
@@ -928,13 +932,15 @@ function confirmDestructiveSelection() {
     local rc=$?
     if [[ ${rc} -ne 0 ]]; then
         info "User '${loggedInUser}' cancelled destructive confirmation"
-        exit 2
+        return "${interactiveCancelReturnCode}"
     fi
 
     if ! grep -Eiq 'confirm_destructive\"?[[:space:]]*:[[:space:]]*(true|1|yes)' "${workDirectory}/destructive.json"; then
         info "Destructive confirmation checkbox not acknowledged"
         exit 2
     fi
+
+    return 0
 }
 
 function startProgressDialog() {
@@ -2567,11 +2573,31 @@ function main() {
     preflightChecks
 
     showIntroDialog
+    local dialogRC=$?
+    if [[ ${dialogRC} -eq ${interactiveCancelReturnCode} ]]; then
+        exit 0
+    elif [[ ${dialogRC} -ne 0 ]]; then
+        exit "${dialogRC}"
+    fi
+
     showSelectionDialog
+    dialogRC=$?
+    if [[ ${dialogRC} -eq ${interactiveCancelReturnCode} ]]; then
+        exit 0
+    elif [[ ${dialogRC} -ne 0 ]]; then
+        exit "${dialogRC}"
+    fi
+
     validateSelectedOperations
     resolveDependencies
     sortOperationsByExecutionPhase
     confirmDestructiveSelection
+    dialogRC=$?
+    if [[ ${dialogRC} -eq ${interactiveCancelReturnCode} ]]; then
+        exit 0
+    elif [[ ${dialogRC} -ne 0 ]]; then
+        exit "${dialogRC}"
+    fi
 
     info "Resolved operations: ${resolvedOperations[*]}"
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 ![GitHub release (latest by date)](https://img.shields.io/github/v/release/dan-snelson/Microsoft-365-Reset?display_name=tag) ![GitHub issues](https://img.shields.io/github/issues-raw/dan-snelson/Microsoft-365-Reset) ![GitHub closed issues](https://img.shields.io/github/issues-closed-raw/dan-snelson/Microsoft-365-Reset) ![GitHub pull requests](https://img.shields.io/github/issues-pr-raw/dan-snelson/Microsoft-365-Reset) ![GitHub closed pull requests](https://img.shields.io/github/issues-pr-closed-raw/dan-snelson/Microsoft-365-Reset)
 
-# Microsoft 365 Reset (1.0.0b2)
+# Microsoft 365 Reset (1.0.0b3)
 
-<img src="images/Microsoft_365_Reset.png" alt="Version 1.0.0b2" width="128" height="128" />
+<img src="images/Microsoft_365_Reset.png" alt="Version 1.0.0b3" width="128" height="128" />
 
 Unified `zsh` script to repair, reset, or remove Microsoft 365 components on macOS:
 
@@ -161,7 +161,7 @@ In interactive modes, a second confirmation dialog is required when any of these
 - `remove_outlook_data`
 - `remove_onenote_data`
 
-If confirmation is cancelled or not acknowledged, script exits with code `2`.
+If the user cancels this confirmation dialog, the script exits cleanly with code `0`. If the confirmation payload is not acknowledged, the script exits with code `2`.
 
 ## Execution Order
 
@@ -242,6 +242,8 @@ sudo ./Microsoft-365-Reset.zsh "" "" "" "self-service" "" --mode silent --operat
 
 For repo maintenance, `scripts/mofa-consult.zsh` can sync a sibling `../MOFA` checkout from upstream MOFA and generate a focused inclusion report for this repo. This helper is not used by `Microsoft-365-Reset.zsh` at runtime.
 
+MOFA is the primary behavior baseline for this repo. Use the package-era reference as secondary context for retained chooser logic, dependency history, and operations that do not have a current MOFA community-script equivalent. If this repo intentionally keeps package-era behavior instead of MOFA behavior, treat that as a documented divergence that needs a defensible reason.
+
 By default, the sync step fast-forwards the sibling MOFA checkout's local `main` branch to `upstream/main` and pushes `origin/main` to keep your fork current. Use `--no-push-origin` to skip the fork push.
 
 Default sync + report:
@@ -249,6 +251,8 @@ Default sync + report:
 ```bash
 ./scripts/mofa-consult.zsh
 ```
+
+After any report-generating run, the helper prints a ready-to-paste Codex prompt for reviewing the generated report in this repo context and copies that prompt to the clipboard when `pbcopy` is available.
 
 Generate a report from the current local MOFA checkout without syncing:
 
@@ -265,6 +269,7 @@ Sync local `main` from `upstream/main` without pushing your fork:
 The report uses `Covered`, `Candidate inclusion`, `Intentional divergence`, `Local-only operation`, and `Skipped` classifications, and compares:
 
 - MOFA community-maintained reset scripts against local operation coverage
+- Package-era Distribution choices retained in the unified workflow even when there is no current MOFA community-script mapping
 - MOFA stable feed metadata from `latest_raw_files/macos_standalone_latest.json`
 - Hard-coded local repair links, MAU application IDs, and current minimum-version thresholds for Teams and MAU
 - Resolved `file://` links back to the sibling MOFA scripts referenced by the report
@@ -273,8 +278,8 @@ The report uses `Covered`, `Candidate inclusion`, `Intentional divergence`, `Loc
 
 | Code | Meaning |
 |---|---|
-| `0` | Success |
-| `2` | User cancelled or no operations provided in `silent` mode |
+| `0` | Success, including intentional user cancellation in interactive modes |
+| `2` | No operations provided in `silent` mode or destructive confirmation was not acknowledged |
 | `10` | Preflight/validation failure |
 | `20` | One or more operations failed |
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The script consolidates expanded package workflows into one root-run tool with:
 - Auto-repair for selected Microsoft apps using Microsoft-hosted packages
 - MOFA community-maintained reset script contents adapted into the unified workflow
 
-[MOFA](https://mofa.cocolabs.dev/macos_tools/microsoft_office_repair_tools.html) parity notes:
+[MOFA](https://mofa.cocolabs.dev/macos_tools/microsoft_office_repair_tools.html) alignment and intentional divergence notes:
 
 - `reset_factory` performs its own MOFA-style suite cleanup in addition to dependency expansion
 - App repair/reinstall flows for Word, Excel, PowerPoint, Outlook, and OneNote now stop after repair instead of continuing with configuration cleanup in the same run
@@ -254,6 +254,8 @@ Default sync + report:
 
 After any report-generating run, the helper prints a ready-to-paste Codex prompt for reviewing the generated report in this repo context and copies that prompt to the clipboard when `pbcopy` is available.
 
+The package-era comparison is optional. When `Resources/Microsoft_Office_Reset_2.0.0b1_expanded/Distribution` is available locally, the report compares retained package-era operations against the unified workflow. When that local reference is absent, the helper warns and marks the package-era section as `Skipped` instead of failing the full report.
+
 Generate a report from the current local MOFA checkout without syncing:
 
 ```bash
@@ -269,7 +271,7 @@ Sync local `main` from `upstream/main` without pushing your fork:
 The report uses `Covered`, `Candidate inclusion`, `Intentional divergence`, `Local-only operation`, and `Skipped` classifications, and compares:
 
 - MOFA community-maintained reset scripts against local operation coverage
-- Package-era Distribution choices retained in the unified workflow even when there is no current MOFA community-script mapping
+- Package-era Distribution choices retained in the unified workflow even when there is no current MOFA community-script mapping, when the local expanded package reference is available
 - MOFA stable feed metadata from `latest_raw_files/macos_standalone_latest.json`
 - Hard-coded local repair links, MAU application IDs, and current minimum-version thresholds for Teams and MAU
 - Resolved `file://` links back to the sibling MOFA scripts referenced by the report

--- a/scripts/mofa-consult.zsh
+++ b/scripts/mofa-consult.zsh
@@ -185,6 +185,62 @@ function distributionContainsChoice() {
     /usr/bin/grep -Fq "${choiceID}" "${distributionPath}"
 }
 
+function appendPackageEraSection() {
+    local distributionURL
+    local operationID
+    local localOpLabel
+    local classification
+    local note
+
+    typeset -A packageChoiceIDForOperation
+    typeset -A packageEraReason
+
+    local packageEraOnlyOperations=(
+        remove_onenote_data
+        remove_defender
+    )
+
+    packageChoiceIDForOperation[remove_onenote_data]="com.microsoft.remove.OneNote.Data"
+    packageChoiceIDForOperation[remove_defender]="com.microsoft.remove.Defender"
+
+    packageEraReason[remove_onenote_data]="Package-era OneNote cached data removal workflow retained from the original Distribution."
+    packageEraReason[remove_defender]="Package-era Defender removal workflow retained from the original Distribution."
+
+    appendReportLine ""
+    appendReportLine "## Package-Era Operations"
+    appendReportLine ""
+
+    if [[ ! -f "${distributionPath}" ]]; then
+        warning "Package-era Distribution not found; skipping package-era coverage section: ${distributionPath}"
+        appendReportLine "_Skipped: package-era Distribution reference not found at \`${distributionPath}\`._"
+        return 0
+    fi
+
+    distributionURL="$(pathToFileURL "${distributionPath}")"
+    appendReportLine "| Package Reference | Local Operation | Classification | Notes |"
+    appendReportLine "| --- | --- | --- | --- |"
+
+    for operationID in "${packageEraOnlyOperations[@]}"; do
+        localOpLabel="${operationID}"
+        classification="Covered"
+        note="${packageEraReason[${operationID}]}"
+
+        if ! distributionContainsChoice "${packageChoiceIDForOperation[${operationID}]}"; then
+            classification="Candidate inclusion"
+            note="Expected package-era Distribution choice ${packageChoiceIDForOperation[${operationID}]} is missing from the local reference."
+            addCandidateItem "${operationID}: expected package-era Distribution choice ${packageChoiceIDForOperation[${operationID}]} is missing"
+        elif ! scriptContainsOperation "${operationID}"; then
+            classification="Candidate inclusion"
+            note="Package-era Distribution includes this operation, but the local operation is missing from Microsoft-365-Reset.zsh."
+            addCandidateItem "${operationID}: package-era Distribution includes this operation but the local operation is missing"
+        else
+            note="${note} Current local operation remains present."
+        fi
+
+        appendReportLine "| [Distribution](${distributionURL}) | \`${localOpLabel}\` | ${classification} | $(escapeForMarkdown "${note}") |"
+    done
+}
+
 function ensureUpstreamRemote() {
     local currentURL
     currentURL="$(git -C "${mofaRepoPath}" remote get-url upstream 2>/dev/null)"
@@ -252,12 +308,9 @@ function buildScriptCoverageSection() {
     local mofaScriptPath
     local mofaScriptURL
     local localOpLabel
-    local distributionURL
 
     typeset -A mofaScriptPathForOperation
     typeset -A intentionalNoteForOperation
-    typeset -A packageChoiceIDForOperation
-    typeset -A packageEraReason
     typeset -A localOnlyReason
 
     local mappedOperations=(
@@ -277,11 +330,6 @@ function buildScriptCoverageSection() {
         remove_skypeforbusiness
         remove_zoomplugin
         remove_webexpt
-    )
-
-    local packageEraOnlyOperations=(
-        remove_onenote_data
-        remove_defender
     )
 
     local localOnlyOperations=(
@@ -316,12 +364,6 @@ function buildScriptCoverageSection() {
     intentionalNoteForOperation[reset_autoupdate]="README parity note: AutoUpdate registration treats new Teams as TEAMS21 while keeping classic Teams on the legacy product ID."
     intentionalNoteForOperation[reset_license]="README parity note: reset_license and reset_credentials split MOFA's license-only and broader sign-in reset flows."
     intentionalNoteForOperation[reset_credentials]="README parity note: reset_license and reset_credentials split MOFA's license-only and broader sign-in reset flows."
-
-    packageChoiceIDForOperation[remove_onenote_data]="com.microsoft.remove.OneNote.Data"
-    packageChoiceIDForOperation[remove_defender]="com.microsoft.remove.Defender"
-
-    packageEraReason[remove_onenote_data]="Package-era OneNote cached data removal workflow retained from the original Distribution."
-    packageEraReason[remove_defender]="Package-era Defender removal workflow retained from the original Distribution."
 
     localOnlyReason[reset_teams_force]="Local-only force-reinstall path for Teams."
     localOnlyReason[remove_acrobat_addin]="Local-only Adobe Acrobat add-in cleanup workflow."
@@ -358,34 +400,7 @@ function buildScriptCoverageSection() {
         appendReportLine "| [$(basename "${mofaScriptRelativePath}")](${mofaScriptURL}) | \`${localOpLabel}\` | ${classification} | $(escapeForMarkdown "${note}") |"
     done
 
-    [[ -f "${distributionPath}" ]] || dieReport "Package-era Distribution not found: ${distributionPath}"
-    distributionURL="$(pathToFileURL "${distributionPath}")"
-
-    appendReportLine ""
-    appendReportLine "## Package-Era Operations"
-    appendReportLine ""
-    appendReportLine "| Package Reference | Local Operation | Classification | Notes |"
-    appendReportLine "| --- | --- | --- | --- |"
-
-    for operationID in "${packageEraOnlyOperations[@]}"; do
-        localOpLabel="${operationID}"
-        classification="Covered"
-        note="${packageEraReason[${operationID}]}"
-
-        if ! distributionContainsChoice "${packageChoiceIDForOperation[${operationID}]}"; then
-            classification="Candidate inclusion"
-            note="Expected package-era Distribution choice ${packageChoiceIDForOperation[${operationID}]} is missing from the local reference."
-            addCandidateItem "${operationID}: expected package-era Distribution choice ${packageChoiceIDForOperation[${operationID}]} is missing"
-        elif ! scriptContainsOperation "${operationID}"; then
-            classification="Candidate inclusion"
-            note="Package-era Distribution includes this operation, but the local operation is missing from Microsoft-365-Reset.zsh."
-            addCandidateItem "${operationID}: package-era Distribution includes this operation but the local operation is missing"
-        else
-            note="${note} Current local operation remains present."
-        fi
-
-        appendReportLine "| [Distribution](${distributionURL}) | \`${localOpLabel}\` | ${classification} | $(escapeForMarkdown "${note}") |"
-    done
+    appendPackageEraSection
 
     appendReportLine ""
     appendReportLine "## Local-Only Operations"

--- a/scripts/mofa-consult.zsh
+++ b/scripts/mofa-consult.zsh
@@ -14,6 +14,7 @@ setopt PIPE_FAIL
 autoload -Uz is-at-least
 
 scriptName="mofa-consult"
+scriptVersion="1.0.0b3"
 defaultMofaRepo="../MOFA"
 defaultOutputPath="/var/tmp/M365R-MOFA-report.md"
 upstreamURL="https://github.com/cocopuff2u/MOFA.git"
@@ -21,6 +22,9 @@ upstreamURL="https://github.com/cocopuff2u/MOFA.git"
 scriptDirectory="$(cd "$(dirname "$0")" && pwd)"
 repoRoot="$(cd "${scriptDirectory}/.." && pwd)"
 m365ScriptPath="${repoRoot}/Microsoft-365-Reset.zsh"
+readmePath="${repoRoot}/README.md"
+agentsPath="${repoRoot}/AGENTS.md"
+distributionPath="${repoRoot}/Resources/Microsoft_Office_Reset_2.0.0b1_expanded/Distribution"
 
 mofaRepoPath="${defaultMofaRepo}"
 outputPath="${defaultOutputPath}"
@@ -96,6 +100,18 @@ function appendReportLine() {
     reportLines+=("${1}")
 }
 
+function emitCodexPrompt() {
+    local codexPrompt
+
+    codexPrompt="Use \$workspace to review ${outputPath}, then inspect ${m365ScriptPath}, ${readmePath}, and ${agentsPath}. Evaluate the candidate inclusion items, intentional divergences, and local-only operations against the current Microsoft 365 Reset behavior and maintainer guidance, then recommend any safe follow-up changes for this repo."
+
+    print -r -- "Codex Chat prompt: ${codexPrompt}"
+    if command -v pbcopy >/dev/null 2>&1; then
+        print -rn -- "${codexPrompt}" | pbcopy
+        print -r -- "Codex Chat prompt copied to clipboard."
+    fi
+}
+
 function addCandidateItem() {
     candidateItems+=("${1}")
 }
@@ -162,6 +178,11 @@ function extractFeedField() {
 function scriptContainsOperation() {
     local operationID="${1}"
     /usr/bin/grep -q "function op_${operationID}()" "${m365ScriptPath}"
+}
+
+function distributionContainsChoice() {
+    local choiceID="${1}"
+    /usr/bin/grep -Fq "${choiceID}" "${distributionPath}"
 }
 
 function ensureUpstreamRemote() {
@@ -231,9 +252,12 @@ function buildScriptCoverageSection() {
     local mofaScriptPath
     local mofaScriptURL
     local localOpLabel
+    local distributionURL
 
     typeset -A mofaScriptPathForOperation
     typeset -A intentionalNoteForOperation
+    typeset -A packageChoiceIDForOperation
+    typeset -A packageEraReason
     typeset -A localOnlyReason
 
     local mappedOperations=(
@@ -255,10 +279,13 @@ function buildScriptCoverageSection() {
         remove_webexpt
     )
 
-    local localOnlyOperations=(
+    local packageEraOnlyOperations=(
         remove_onenote_data
-        reset_teams_force
         remove_defender
+    )
+
+    local localOnlyOperations=(
+        reset_teams_force
         remove_acrobat_addin
     )
 
@@ -290,9 +317,13 @@ function buildScriptCoverageSection() {
     intentionalNoteForOperation[reset_license]="README parity note: reset_license and reset_credentials split MOFA's license-only and broader sign-in reset flows."
     intentionalNoteForOperation[reset_credentials]="README parity note: reset_license and reset_credentials split MOFA's license-only and broader sign-in reset flows."
 
-    localOnlyReason[remove_onenote_data]="Local-only cached OneNote data removal workflow."
+    packageChoiceIDForOperation[remove_onenote_data]="com.microsoft.remove.OneNote.Data"
+    packageChoiceIDForOperation[remove_defender]="com.microsoft.remove.Defender"
+
+    packageEraReason[remove_onenote_data]="Package-era OneNote cached data removal workflow retained from the original Distribution."
+    packageEraReason[remove_defender]="Package-era Defender removal workflow retained from the original Distribution."
+
     localOnlyReason[reset_teams_force]="Local-only force-reinstall path for Teams."
-    localOnlyReason[remove_defender]="Local-only Defender removal workflow."
     localOnlyReason[remove_acrobat_addin]="Local-only Adobe Acrobat add-in cleanup workflow."
 
     appendReportLine "## Script Coverage"
@@ -325,6 +356,35 @@ function buildScriptCoverageSection() {
         fi
 
         appendReportLine "| [$(basename "${mofaScriptRelativePath}")](${mofaScriptURL}) | \`${localOpLabel}\` | ${classification} | $(escapeForMarkdown "${note}") |"
+    done
+
+    [[ -f "${distributionPath}" ]] || dieReport "Package-era Distribution not found: ${distributionPath}"
+    distributionURL="$(pathToFileURL "${distributionPath}")"
+
+    appendReportLine ""
+    appendReportLine "## Package-Era Operations"
+    appendReportLine ""
+    appendReportLine "| Package Reference | Local Operation | Classification | Notes |"
+    appendReportLine "| --- | --- | --- | --- |"
+
+    for operationID in "${packageEraOnlyOperations[@]}"; do
+        localOpLabel="${operationID}"
+        classification="Covered"
+        note="${packageEraReason[${operationID}]}"
+
+        if ! distributionContainsChoice "${packageChoiceIDForOperation[${operationID}]}"; then
+            classification="Candidate inclusion"
+            note="Expected package-era Distribution choice ${packageChoiceIDForOperation[${operationID}]} is missing from the local reference."
+            addCandidateItem "${operationID}: expected package-era Distribution choice ${packageChoiceIDForOperation[${operationID}]} is missing"
+        elif ! scriptContainsOperation "${operationID}"; then
+            classification="Candidate inclusion"
+            note="Package-era Distribution includes this operation, but the local operation is missing from Microsoft-365-Reset.zsh."
+            addCandidateItem "${operationID}: package-era Distribution includes this operation but the local operation is missing"
+        else
+            note="${note} Current local operation remains present."
+        fi
+
+        appendReportLine "| [Distribution](${distributionURL}) | \`${localOpLabel}\` | ${classification} | $(escapeForMarkdown "${note}") |"
     done
 
     appendReportLine ""
@@ -556,6 +616,7 @@ function buildReport() {
     buildScriptCoverageSection
     buildFeedComparisonSection
     writeReport
+    emitCodexPrompt
 }
 
 function validateInputs() {


### PR DESCRIPTION
## 06-Apr-2026

- Fresh run of `scripts/mofa-consult.zsh` to sync with the latest MOFA stable feed and generate an updated local inclusion report for this repo
- Modified interactive user cancellations to exit cleanly so Jamf Pro policy logs do not report them as failures.