### PR TITLE
1.2.0b2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,12 @@
 
 ## Changelog
 
-### Version 1.2.0b1 (16-May-2026)
+### Version 1.2.0b2 (16-May-2026)
 - Reviewed [MOFA](https://github.com/cocopuff2u/MOFA) repo
 - Reclassified `reset_license` and `reset_credentials` as MOFA-aligned coverage in `scripts/mofa-consult.zsh` instead of intentional divergences
 - Clarified `README.md` MOFA notes to separate aligned behavior, intentional divergences, and repo-local operations
 - Fixed `--operations` / Jamf `$5` CSV parsing so comma-separated operation IDs execute as separate selections in `silent` mode (Addresses #16; thanks for the detailed report and recommended fix, @meschwartz!)
+- Constrained interactive operation picker to CSV-listed operations when `--operations` / Jamf `$5` is provided in `self-service`, `test`, or `debug` mode (Addresses #15; thanks for the suggestion, @andreilabin!)
 
 ### Version 1.1.0 (01-May-2026)
 - Reviewed [MOFA](https://github.com/cocopuff2u/MOFA) repo

--- a/Microsoft-365-Reset.zsh
+++ b/Microsoft-365-Reset.zsh
@@ -12,10 +12,11 @@
 #
 # HISTORY
 #
-# Version 1.2.0b1, 16-May-2026, Dan K. Snelson (@dan-snelson)
+# Version 1.2.0b2, 16-May-2026, Dan K. Snelson (@dan-snelson)
 # - Reclassified `reset_license` and `reset_credentials` as MOFA-aligned coverage in `scripts/mofa-consult.zsh` instead of intentional divergences
 # - Clarified `README.md` MOFA notes to separate aligned behavior, intentional divergences, and repo-local operations
 # - Fixed `--operations` / Jamf `$5` CSV parsing so comma-separated operation IDs execute as separate selections in `silent` mode (Addresses #16; thanks for the detailed report and recommended fix, @meschwartz!)
+# - Constrained interactive operation picker to CSV-listed operations when `--operations` / Jamf `$5` is provided in `self-service`, `test`, or `debug` mode (Addresses #15; thanks for the suggestion, @andreilabin!)
 #
 ####################################################################################################
 
@@ -31,7 +32,7 @@ export PATH=/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin/
 setopt NONOMATCH
 
 # Script identity
-scriptVersion="1.2.0b1"
+scriptVersion="1.2.0b2"
 humanReadableScriptName="Microsoft 365 Reset"
 scriptName="M365R"
 
@@ -793,6 +794,15 @@ function parseDialogSelections() {
     fi
 }
 
+function validateOperationIDs() {
+    local op
+    for op in "$@"; do
+        if [[ -z "${operationTitle[${op}]}" ]]; then
+            fatal "Invalid operation ID requested: ${op}"
+        fi
+    done
+}
+
 function showSelectionDialog() {
     if [[ "${operationMode}" == "silent" ]]; then
         parseOperationCSV "${operationCSV}"
@@ -800,14 +810,27 @@ function showSelectionDialog() {
     fi
 
     local checkboxArgs=()
+    local allowedOperations=()
     local op
     local baseMessage
     local warningMessage=""
     local messageText
     local dialogOutput
     local rc
+    local normalizedOperationCSV="${operationCSV//[[:space:]]/}"
 
-    for op in "${operationIDs[@]}"; do
+    normalizedOperationCSV="${normalizedOperationCSV//,/}"
+
+    if [[ -n "${normalizedOperationCSV}" ]]; then
+        parseOperationCSV "${operationCSV}"
+        validateOperationIDs "${selectedOperations[@]}"
+        allowedOperations=("${selectedOperations[@]}")
+        selectedOperations=()
+    else
+        allowedOperations=("${operationIDs[@]}")
+    fi
+
+    for op in "${allowedOperations[@]}"; do
         checkboxArgs+=(--checkbox "${operationTitle[${op}]},name=${op},icon=${operationIcon[${op}]}")
     done
 
@@ -2591,12 +2614,7 @@ function validateSelectedOperations() {
         return 0
     fi
 
-    local op
-    for op in "${selectedOperations[@]}"; do
-        if [[ -z "${operationTitle[${op}]}" ]]; then
-            fatal "Invalid operation ID requested: ${op}"
-        fi
-    done
+    validateOperationIDs "${selectedOperations[@]}"
 }
 
 function main() {

--- a/Microsoft-365-Reset.zsh
+++ b/Microsoft-365-Reset.zsh
@@ -811,6 +811,7 @@ function showSelectionDialog() {
 
     local checkboxArgs=()
     local allowedOperations=()
+    local includesRemoveOffice="false"
     local op
     local baseMessage
     local warningMessage=""
@@ -832,9 +833,13 @@ function showSelectionDialog() {
 
     for op in "${allowedOperations[@]}"; do
         checkboxArgs+=(--checkbox "${operationTitle[${op}]},name=${op},icon=${operationIcon[${op}]}")
+        [[ "${op}" == "remove_office" ]] && includesRemoveOffice="true"
     done
 
-    baseMessage="Select one or more reset / removal operations.\n\nNote: Choosing **Completely remove Microsoft 365** suppresses reset-related actions."
+    baseMessage="Select one or more reset / removal operations."
+    if [[ "${includesRemoveOffice}" == "true" ]]; then
+        baseMessage="${baseMessage}\n\nNote: Choosing **Completely remove Microsoft 365** suppresses reset-related actions."
+    fi
 
     while true; do
         messageText="${baseMessage}"

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ Interactive run with chooser limited to Outlook-safe reset operations:
 ```bash
 sudo ./Microsoft-365-Reset.zsh \
   --mode self-service \
-  --operations reset_outlook,reset_credentials,reset_license
+  --operations reset_outlook,reset_credentials
 ```
 
 Silent run with explicit operations:

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 ![GitHub release (latest by date)](https://img.shields.io/github/v/release/dan-snelson/Microsoft-365-Reset?display_name=tag) ![GitHub issues](https://img.shields.io/github/issues-raw/dan-snelson/Microsoft-365-Reset) ![GitHub closed issues](https://img.shields.io/github/issues-closed-raw/dan-snelson/Microsoft-365-Reset) ![GitHub pull requests](https://img.shields.io/github/issues-pr-raw/dan-snelson/Microsoft-365-Reset) ![GitHub closed pull requests](https://img.shields.io/github/issues-pr-closed-raw/dan-snelson/Microsoft-365-Reset) [![swiftDialog](https://img.shields.io/badge/swiftDialog-Enabled-blue)](https://swiftdialog.app) [![Semgrep Security Scan](https://img.shields.io/badge/security%20scanned%20by-Semgrep-00C7B7?style=flat&logo=semgrep&logoColor=white)](https://semgrep.dev)
 
-# Microsoft 365 Reset (1.2.0b1)
+# Microsoft 365 Reset (1.2.0b2)
 
-<img src="images/Microsoft_365_Reset.png" alt="Version 1.2.0b1" width="128" height="128" />
+<img src="images/Microsoft_365_Reset.png" alt="Version 1.2.0b2" width="128" height="128" />
 
 Unified `zsh` script to repair, reset, or remove Microsoft 365 components on macOS:
 
@@ -82,7 +82,7 @@ sudo ./Microsoft-365-Reset.zsh [--mode MODE] [--operations CSV]
 | Argument | Default | Description |
 |---|---|---|
 | `--mode` | `self-service` | `self-service`, `silent`, `test`, `debug` |
-| `--operations` | empty | Comma-separated operation IDs (primarily for `silent`) |
+| `--operations` | empty | Comma-separated operation IDs; required for `silent`, and constrains interactive chooser options in `self-service`, `test`, and `debug` when provided |
 
 Checkbox style is hard-coded to `switch,large` in the interactive selection UI, and each option includes its own operation icon.
 
@@ -101,14 +101,14 @@ CLI flags (`--mode`, `--operations`) override these values when both are present
 
 | Mode | Behavior |
 |---|---|
-| `self-service` | Full interactive flow (intro, selection, destructive confirmation, resolved-operation progress summary, completion) |
-| `test` | Interactive flow, useful for operator testing |
-| `debug` | Interactive flow + `set -x` |
+| `self-service` | Full interactive flow (intro, selection, destructive confirmation, resolved-operation progress summary, completion); when `--operations`/`$5` is provided, the selection dialog shows only those operation IDs |
+| `test` | Interactive flow, useful for operator testing; honors `--operations`/`$5` as chooser constraint when provided |
+| `debug` | Interactive flow + `set -x`; honors `--operations`/`$5` as chooser constraint when provided |
 | `silent` | No dialogs; operations must be provided via `--operations`/`$5` |
 
 ## Supported Operations
 
-Use these IDs in `--operations` CSV:
+Use these IDs in `--operations` CSV for silent execution or interactive chooser filtering:
 
 | ID | Purpose |
 |---|---|
@@ -213,6 +213,14 @@ Interactive (default):
 
 ```bash
 sudo ./Microsoft-365-Reset.zsh
+```
+
+Interactive run with chooser limited to Outlook-safe reset operations:
+
+```bash
+sudo ./Microsoft-365-Reset.zsh \
+  --mode self-service \
+  --operations reset_outlook,reset_credentials,reset_license
 ```
 
 Silent run with explicit operations:


### PR DESCRIPTION
- Constrained interactive operation picker to CSV-listed operations when `--operations` / Jamf `$5` is provided in `self-service`, `test`, or `debug` mode (Addresses #15; thanks for the suggestion, @andreilabin!)