### PR TITLE
1.3.0

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -38,7 +38,7 @@ jobs:
     steps:
       - name: Check Out Repository
         # Fetch full history so diff-aware scans and code scanning uploads have the right context.
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           fetch-depth: 0
 
@@ -46,7 +46,7 @@ jobs:
         id: semgrep_action
         # Requested official action. It is archived upstream, so a CLI step below handles SARIF export.
         continue-on-error: true
-        uses: semgrep/semgrep-action@v1
+        uses: semgrep/semgrep-action@713efdd345f3035192eaa63f56867b88e63e4e5d # v1
         env:
           SEMGREP_BASELINE_COMMIT: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || '' }}
         with:
@@ -121,7 +121,7 @@ jobs:
         id: upload_sarif
         if: hashFiles('semgrep.sarif') != ''
         # Repo Actions permissions must allow SARIF uploads or this step will fail even with security-events: write.
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4
         with:
           sarif_file: semgrep.sarif
           category: semgrep
@@ -167,14 +167,14 @@ jobs:
     steps:
       - name: Check Out Repository
         # Fetch full history so Gitleaks can scan past commits on protected branches.
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           fetch-depth: 0
 
       - name: Run Gitleaks (Blocking)
         id: gitleaks_scan
         continue-on-error: true
-        uses: gitleaks/gitleaks-action@v2
+        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITLEAKS_ENABLE_COMMENTS: "true"
@@ -213,7 +213,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check Out Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           fetch-depth: 0
 
@@ -286,7 +286,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check Out Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           fetch-depth: 0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Changelog
 
+### Version 1.3.0b1 (30-Jul-2026)
+- Reviewed [MOFA](https://github.com/cocopuff2u/MOFA) repo
+    - Reclassified deferred app cleanup after repair as MOFA-aligned behavior and narrowed the documented Teams divergences
+    - Ensured `reset_teams_force` installs current Teams when no app bundle exists
+    - Hardened MOFA reporting to validate complete operation wiring and expected runtime metadata before reporting coverage
+- Aligned the selection dialog icon and overlay icon with the intro dialog
+- Pinned seven GitHub Actions to immutable commit SHAs, clearing all Semgrep findings
+
 ### Version 1.2.0 (20-May-2026)
 - Reviewed [MOFA](https://github.com/cocopuff2u/MOFA) repo
 - Reclassified `reset_license` and `reset_credentials` as MOFA-aligned coverage in `scripts/mofa-consult.zsh` instead of intentional divergences

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Changelog
 
-### Version 1.3.0b1 (30-Jul-2026)
+### Version 1.3.0 (04-Aug-2026)
 - Reviewed [MOFA](https://github.com/cocopuff2u/MOFA) repo
     - Reclassified deferred app cleanup after repair as MOFA-aligned behavior and narrowed the documented Teams divergences
     - Ensured `reset_teams_force` installs current Teams when no app bundle exists

--- a/Microsoft-365-Reset.zsh
+++ b/Microsoft-365-Reset.zsh
@@ -12,11 +12,13 @@
 #
 # HISTORY
 #
-# Version 1.2.0, 20-May-2026, Dan K. Snelson (@dan-snelson)
-# - Reclassified `reset_license` and `reset_credentials` as MOFA-aligned coverage in `scripts/mofa-consult.zsh` instead of intentional divergences
-# - Clarified `README.md` MOFA notes to separate aligned behavior, intentional divergences, and repo-local operations
-# - Fixed `--operations` / Jamf `$5` CSV parsing so comma-separated operation IDs execute as separate selections in `silent` mode (Addresses #16; thanks for the detailed report and recommended fix, @meschwartz!)
-# - Constrained interactive operation picker to CSV-listed operations when `--operations` / Jamf `$5` is provided in `self-service`, `test`, or `debug` mode (Addresses #15; thanks for the suggestion, @andreilabin!)
+# Version 1.3.0b1, 30-Jul-2026, Dan K. Snelson (@dan-snelson)
+# - Reviewed [MOFA](https://github.com/cocopuff2u/MOFA) repo
+#   - Reclassified deferred app cleanup after repair as MOFA-aligned behavior and narrowed the documented Teams divergences
+#   - Ensured `reset_teams_force` installs current Teams when no app bundle exists
+#   - Hardened MOFA reporting to validate complete operation wiring and expected runtime metadata before reporting coverage
+# - Aligned the selection dialog icon and overlay icon with the intro dialog
+# - Pinned seven GitHub Actions to immutable commit SHAs, clearing all Semgrep findings
 #
 ####################################################################################################
 
@@ -32,7 +34,7 @@ export PATH=/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin/
 setopt NONOMATCH
 
 # Script identity
-scriptVersion="1.2.0"
+scriptVersion="1.3.0b1"
 humanReadableScriptName="Microsoft 365 Reset"
 scriptName="M365R"
 
@@ -192,7 +194,7 @@ operationDescription[reset_onenote]="Closes Microsoft OneNote, checks for damage
 operationDescription[remove_onenote_data]="Closes Microsoft OneNote and removes cached data. Warning: This will remove any content that has not synchronized with the cloud."
 operationDescription[reset_onedrive]="Closes Microsoft OneDrive, checks for damage and performs repairs as necessary. Resets caches and configuration data. This will not remove your synchronized OneDrive files."
 operationDescription[reset_teams]="Closes Microsoft Teams, checks for damage and performs repairs as necessary. Resets caches, credentials and configuration data."
-operationDescription[reset_teams_force]="Closes Microsoft Teams, removes the current Teams app bundle, reinstalls the latest version, and then resets Teams caches, credentials and configuration data."
+operationDescription[reset_teams_force]="Closes Microsoft Teams, removes any installed Teams app bundles, installs the latest current Teams version, and then resets Teams caches, credentials and configuration data."
 operationDescription[reset_autoupdate]="Resets Microsoft AutoUpdate to default settings and installs the latest version of the tool."
 operationDescription[reset_license]="Closes all apps and removes Office licensing files plus core Office identity data without the broader Teams and OneDrive sign-in cleanup."
 operationDescription[reset_credentials]="Closes all apps and removes the Office license files. Sign-in credentials and cached tokens are removed from keychain."
@@ -658,7 +660,7 @@ function maybeRepairOfficeApp() {
     fi
 
     if [[ "${repairPerformed}" == "true" ]]; then
-        info "${appName} repair completed; skipping configuration cleanup for this run as a documented divergence from MOFA"
+        info "${appName} repair completed; skipping configuration cleanup for this run to match current MOFA behavior"
         return 2
     fi
 
@@ -852,7 +854,8 @@ function showSelectionDialog() {
             --infotext "${scriptVersion}" \
             --messagefont "size=${fontSize}" \
             --message "${messageText}" \
-            --icon "https://usw2.ics.services.jamfcloud.com/icon/hash_a0bc0557b531bc5d2713dece4f513df1ac5038ff55ebf5115edf43b951f916c7" \
+            --icon "${applicationIcon}" \
+            --overlayicon "${organizationOverlayiconURL}" \
             --checkboxstyle "switch,large" \
             --json \
             --button1text "Run" \
@@ -1957,7 +1960,7 @@ function resetTeamsOperation() {
     local teamsBackgroundArchive="${loggedInUserHome}/Teams_Old_Backgrounds"
     local installAttempt=1
     local installationRetries=5
-    local shouldInstallTeams="false"
+    local shouldInstallTeams="${forceReinstall}"
     osVersion="$(sw_vers -productVersion)"
 
     pkill -9 'MSTeams' 2>/dev/null

--- a/Microsoft-365-Reset.zsh
+++ b/Microsoft-365-Reset.zsh
@@ -1072,7 +1072,7 @@ function finishProgressDialog() {
 function showCompletionDialog() {
     [[ "${operationMode}" == "silent" ]] && return 0
 
-    local summary="**Results**<br><br>- Completed operations: ${#completedOperations[@]}<br>- Failed operations: ${#failedOperations[@]}<br>- Elapsed Time: $(formattedElapsedTime)"
+    local summary="**Results:**<br><br>- Completed operations: ${#completedOperations[@]}<br>- Failed operations: ${#failedOperations[@]}<br><br>**Elapsed Time:** $(formattedElapsedTime)"
     local repairedTitles=()
     local op
 

--- a/Microsoft-365-Reset.zsh
+++ b/Microsoft-365-Reset.zsh
@@ -12,7 +12,7 @@
 #
 # HISTORY
 #
-# Version 1.3.0b1, 30-Jul-2026, Dan K. Snelson (@dan-snelson)
+# Version 1.3.0, 04-Aug-2026, Dan K. Snelson (@dan-snelson)
 # - Reviewed [MOFA](https://github.com/cocopuff2u/MOFA) repo
 #   - Reclassified deferred app cleanup after repair as MOFA-aligned behavior and narrowed the documented Teams divergences
 #   - Ensured `reset_teams_force` installs current Teams when no app bundle exists
@@ -34,7 +34,7 @@ export PATH=/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin/
 setopt NONOMATCH
 
 # Script identity
-scriptVersion="1.3.0b1"
+scriptVersion="1.3.0"
 humanReadableScriptName="Microsoft 365 Reset"
 scriptName="M365R"
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 ![GitHub release (latest by date)](https://img.shields.io/github/v/release/dan-snelson/Microsoft-365-Reset?display_name=tag) ![GitHub issues](https://img.shields.io/github/issues-raw/dan-snelson/Microsoft-365-Reset) ![GitHub closed issues](https://img.shields.io/github/issues-closed-raw/dan-snelson/Microsoft-365-Reset) ![GitHub pull requests](https://img.shields.io/github/issues-pr-raw/dan-snelson/Microsoft-365-Reset) ![GitHub closed pull requests](https://img.shields.io/github/issues-pr-closed-raw/dan-snelson/Microsoft-365-Reset) [![swiftDialog](https://img.shields.io/badge/swiftDialog-Enabled-blue)](https://swiftdialog.app) [![Semgrep Security Scan](https://img.shields.io/badge/security%20scanned%20by-Semgrep-00C7B7?style=flat&logo=semgrep&logoColor=white)](https://semgrep.dev)
 
-# Microsoft 365 Reset (1.2.0)
+# Microsoft 365 Reset (1.3.0b1)
 
-<img src="images/Microsoft_365_Reset_Hero.png" alt="Version 1.2.0" width="600" />
+<img src="images/Microsoft_365_Reset_Hero.png" alt="Version 1.3.0b1" width="600" />
 
 Unified `zsh` script to repair, reset, or remove Microsoft 365 components on macOS:
 
@@ -25,18 +25,19 @@ The script consolidates expanded package workflows into one root-run tool with:
 [MOFA](https://mofa.cocolabs.dev/macos_tools/microsoft_office_repair_tools.html) alignment notes:
 
 - Separate `reset_license` and `reset_credentials` operations align with MOFA's separate license-only and broader sign-in reset flows
+- App repair/reinstall flows for Word, Excel, PowerPoint, Outlook, and OneNote stop after repair without continuing into configuration cleanup, matching current MOFA behavior
+- Teams background preservation, TCC reset, and retention of a valid current Teams app bundle align with current MOFA behavior
 
 Intentional divergences from current MOFA behavior:
 
 - `reset_factory` performs its own MOFA-style suite cleanup in addition to dependency expansion
-- App repair/reinstall flows for Word, Excel, PowerPoint, Outlook, and OneNote now stop after repair instead of continuing with configuration cleanup in the same run
-- `reset_teams` preserves Teams backgrounds, resets Teams TCC state, and opens Screen Recording settings in interactive modes
-- `reset_teams` preserves installed Teams app bundles unless repair is required; `reset_teams_force` performs the explicit app removal and reinstall path
-- Teams reset and AutoUpdate registration now treat new Teams as the current `TEAMS21` product while keeping classic Teams on the legacy product ID
+- `reset_teams` suppresses Screen Recording settings in `silent` mode, preserves classic and work-or-school Teams bundles during a standard reset, and does not install current Teams when its main app bundle is absent
+- AutoUpdate registration treats new Teams as the current `TEAMS21` product while keeping classic Teams on the legacy product ID
 
 Repo-local operations without current MOFA community-script equivalents:
 
-- `reset_teams_force` and `remove_acrobat_addin` remain repo-local workflows without current MOFA community-script equivalents
+- `reset_teams_force` is a repo-local operation ID that exposes the force-reinstall behavior available through MOFA Teams reset's `INSTALL=force` argument; MOFA does not provide a separate force-reset script
+- `remove_acrobat_addin` remains a repo-local workflow without a current MOFA community-script equivalent
 
 ## Screenshots
 
@@ -120,8 +121,8 @@ Use these IDs in `--operations` CSV for silent execution or interactive chooser 
 | `reset_onenote` | OneNote repair/reinstall when needed, or container/group cleanup when no repair occurs |
 | `remove_onenote_data` | Remove OneNote cached local data |
 | `reset_onedrive` | OneDrive repair checks + cache/container/keychain cleanup |
-| `reset_teams` | Teams reset with app validation/repair when needed + Teams cache/container/keychain cleanup |
-| `reset_teams_force` | Force-remove and reinstall Teams, then perform Teams cache/container/keychain cleanup |
+| `reset_teams` | Teams reset with installed-app validation/repair + Teams cache/container/keychain cleanup; leaves current Teams absent when no main app bundle exists |
+| `reset_teams_force` | Force-remove installed Teams variants, install current Teams even when its main bundle was absent, then perform Teams cache/container/keychain cleanup |
 | `reset_autoupdate` | Reset MAU prefs/cache and reinstall/update MAU when applicable |
 | `reset_license` | Reset Office licensing files and core Office identity data |
 | `reset_credentials` | Remove Office licensing/sign-in artifacts and token/keychain data |
@@ -293,6 +294,8 @@ The report uses `Covered`, `Candidate inclusion`, `Intentional divergence`, `Loc
 - MOFA stable feed metadata from `latest_raw_files/macos_standalone_latest.json`
 - Hard-coded local repair links, MAU application IDs, and current minimum-version thresholds for Teams and MAU
 - Resolved `file://` links back to the sibling MOFA scripts referenced by the report
+
+Local operation coverage requires the operation ID, implementation function, dispatcher entry, and deterministic execution-phase entry. Expected local repair URLs, application IDs, and minimum-version thresholds must also remain present in `Microsoft-365-Reset.zsh`. These are structural and metadata checks; semantic parity still requires implementation review.
 
 ## Exit Codes
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 ![GitHub release (latest by date)](https://img.shields.io/github/v/release/dan-snelson/Microsoft-365-Reset?display_name=tag) ![GitHub issues](https://img.shields.io/github/issues-raw/dan-snelson/Microsoft-365-Reset) ![GitHub closed issues](https://img.shields.io/github/issues-closed-raw/dan-snelson/Microsoft-365-Reset) ![GitHub pull requests](https://img.shields.io/github/issues-pr-raw/dan-snelson/Microsoft-365-Reset) ![GitHub closed pull requests](https://img.shields.io/github/issues-pr-closed-raw/dan-snelson/Microsoft-365-Reset) [![swiftDialog](https://img.shields.io/badge/swiftDialog-Enabled-blue)](https://swiftdialog.app) [![Semgrep Security Scan](https://img.shields.io/badge/security%20scanned%20by-Semgrep-00C7B7?style=flat&logo=semgrep&logoColor=white)](https://semgrep.dev)
 
-# Microsoft 365 Reset (1.3.0b1)
+# Microsoft 365 Reset (1.3.0)
 
-<img src="images/Microsoft_365_Reset_Hero.png" alt="Version 1.3.0b1" width="600" />
+<img src="images/Microsoft_365_Reset_Hero.png" alt="Version 1.3.0" width="600" />
 
 Unified `zsh` script to repair, reset, or remove Microsoft 365 components on macOS:
 

--- a/scripts/mofa-consult.zsh
+++ b/scripts/mofa-consult.zsh
@@ -175,9 +175,90 @@ function extractFeedField() {
     ' "${feedPath}"
 }
 
+function scriptDeclaresOperationID() {
+    local operationID="${1}"
+    /usr/bin/awk -v target_operation="${operationID}" '
+        /^operationIDs=\(/ {
+            in_operation_ids=1
+            next
+        }
+
+        in_operation_ids && /^[[:space:]]*\)/ {
+            in_operation_ids=0
+        }
+
+        in_operation_ids {
+            value=$0
+            gsub(/^[[:space:]]+|[[:space:]]+$/, "", value)
+            if (value == target_operation) {
+                found=1
+            }
+        }
+
+        END {
+            exit(found ? 0 : 1)
+        }
+    ' "${m365ScriptPath}"
+}
+
+function scriptImplementsOperation() {
+    local operationID="${1}"
+    /usr/bin/grep -Eq "^function op_${operationID}\\(\\) \\{" "${m365ScriptPath}"
+}
+
+function scriptDispatchesOperation() {
+    local operationID="${1}"
+    /usr/bin/grep -Eq "^[[:space:]]*${operationID}\\)[[:space:]]+op_${operationID}[[:space:]]*;;" "${m365ScriptPath}"
+}
+
+function scriptSchedulesOperation() {
+    local operationID="${1}"
+    /usr/bin/awk -v target_operation="${operationID}" '
+        /^function sortOperationsByExecutionPhase\(\) \{/ {
+            in_sort_function=1
+            next
+        }
+
+        in_sort_function {
+            token_pattern="(^|[^[:alnum:]_])" target_operation "([^[:alnum:]_]|$)"
+            if ($0 !~ /^[[:space:]]*#/ && $0 ~ token_pattern) {
+                found=1
+            }
+        }
+
+        in_sort_function && /^}/ {
+            in_sort_function=0
+        }
+
+        END {
+            exit(found ? 0 : 1)
+        }
+    ' "${m365ScriptPath}"
+}
+
 function scriptContainsOperation() {
     local operationID="${1}"
-    /usr/bin/grep -q "function op_${operationID}()" "${m365ScriptPath}"
+    scriptDeclaresOperationID "${operationID}" &&
+        scriptImplementsOperation "${operationID}" &&
+        scriptDispatchesOperation "${operationID}" &&
+        scriptSchedulesOperation "${operationID}"
+}
+
+function scriptContainsLiteral() {
+    local expectedValue="${1}"
+    /usr/bin/awk -v expected_value="${expectedValue}" '
+        /^[[:space:]]*#/ {
+            next
+        }
+
+        index($0, expected_value) > 0 {
+            found=1
+        }
+
+        END {
+            exit(found ? 0 : 1)
+        }
+    ' "${m365ScriptPath}"
 }
 
 function distributionContainsChoice() {
@@ -231,8 +312,8 @@ function appendPackageEraSection() {
             addCandidateItem "${operationID}: expected package-era Distribution choice ${packageChoiceIDForOperation[${operationID}]} is missing"
         elif ! scriptContainsOperation "${operationID}"; then
             classification="Candidate inclusion"
-            note="Package-era Distribution includes this operation, but the local operation is missing from Microsoft-365-Reset.zsh."
-            addCandidateItem "${operationID}: package-era Distribution includes this operation but the local operation is missing"
+            note="Package-era Distribution includes this operation, but the local operation is not fully wired through metadata, implementation, dispatch, and execution ordering."
+            addCandidateItem "${operationID}: package-era Distribution includes this operation but the local operation is not fully wired"
         else
             note="${note} Current local operation remains present."
         fi
@@ -310,6 +391,7 @@ function buildScriptCoverageSection() {
     local localOpLabel
 
     typeset -A mofaScriptPathForOperation
+    typeset -A coveredNoteForOperation
     typeset -A intentionalNoteForOperation
     typeset -A localOnlyReason
 
@@ -354,16 +436,17 @@ function buildScriptCoverageSection() {
     mofaScriptPathForOperation[remove_zoomplugin]="office_reset_tools/mofa_community_maintained/scripts/MOFA_Community_ZoomPlugin_Removal.zsh"
     mofaScriptPathForOperation[remove_webexpt]="office_reset_tools/mofa_community_maintained/scripts/MOFA_Community_WebExPT_Removal.zsh"
 
+    coveredNoteForOperation[reset_word]="Current MOFA repair flow exits without removing configuration data after repair; local deferred cleanup matches that behavior."
+    coveredNoteForOperation[reset_excel]="Current MOFA repair flow exits without removing configuration data after repair; local deferred cleanup matches that behavior."
+    coveredNoteForOperation[reset_powerpoint]="Current MOFA repair flow exits without removing configuration data after repair; local deferred cleanup matches that behavior."
+    coveredNoteForOperation[reset_outlook]="Current MOFA repair flow exits without removing configuration data after repair; local deferred cleanup matches that behavior."
+    coveredNoteForOperation[reset_onenote]="Current MOFA repair flow exits without removing configuration data after repair; local deferred cleanup matches that behavior."
+
     intentionalNoteForOperation[reset_factory]="README parity note: reset_factory performs its own MOFA-style suite cleanup in addition to dependency expansion."
-    intentionalNoteForOperation[reset_word]="README parity note: Word, Excel, PowerPoint, Outlook, and OneNote stop after repair instead of continuing with configuration cleanup."
-    intentionalNoteForOperation[reset_excel]="README parity note: Word, Excel, PowerPoint, Outlook, and OneNote stop after repair instead of continuing with configuration cleanup."
-    intentionalNoteForOperation[reset_powerpoint]="README parity note: Word, Excel, PowerPoint, Outlook, and OneNote stop after repair instead of continuing with configuration cleanup."
-    intentionalNoteForOperation[reset_outlook]="README parity note: Word, Excel, PowerPoint, Outlook, and OneNote stop after repair instead of continuing with configuration cleanup."
-    intentionalNoteForOperation[reset_onenote]="README parity note: Word, Excel, PowerPoint, Outlook, and OneNote stop after repair instead of continuing with configuration cleanup."
-    intentionalNoteForOperation[reset_teams]="README parity note: reset_teams preserves Teams backgrounds, resets Teams TCC state, opens Screen Recording settings in interactive modes, and preserves app bundles unless repair is required."
+    intentionalNoteForOperation[reset_teams]="README parity note: reset_teams suppresses Screen Recording UI in silent mode, preserves legacy Teams bundles during a standard reset, and does not install Teams when the main bundle is absent. Background preservation and TCC reset remain MOFA-aligned."
     intentionalNoteForOperation[reset_autoupdate]="README parity note: AutoUpdate registration treats new Teams as TEAMS21 while keeping classic Teams on the legacy product ID."
 
-    localOnlyReason[reset_teams_force]="Local-only force-reinstall path for Teams."
+    localOnlyReason[reset_teams_force]="Repo-local operation ID exposing the force-reinstall behavior available through MOFA Teams reset's INSTALL=force argument; no separate MOFA script exists."
     localOnlyReason[remove_acrobat_addin]="Local-only Adobe Acrobat add-in cleanup workflow."
 
     appendReportLine "## Script Coverage"
@@ -385,14 +468,16 @@ function buildScriptCoverageSection() {
             addCandidateItem "${operationID}: expected MOFA script missing at ${mofaScriptRelativePath}"
         elif ! scriptContainsOperation "${operationID}"; then
             classification="Candidate inclusion"
-            note="Mapped local operation is not present in Microsoft-365-Reset.zsh."
-            addCandidateItem "${operationID}: mapped MOFA script exists but local operation is missing"
+            note="Mapped local operation is not fully wired through metadata, implementation, dispatch, and execution ordering."
+            addCandidateItem "${operationID}: mapped MOFA script exists but local operation is not fully wired"
         elif [[ -n "${intentionalNoteForOperation[${operationID}]}" ]]; then
             classification="Intentional divergence"
             note="${intentionalNoteForOperation[${operationID}]}"
             addIntentionalItem "${operationID}: ${note}"
+        elif [[ -n "${coveredNoteForOperation[${operationID}]}" ]]; then
+            note="${coveredNoteForOperation[${operationID}]}"
         else
-            note="Mapped MOFA community script is represented by a local operation."
+            note="Mapped MOFA community script is represented by a fully wired local operation."
         fi
 
         appendReportLine "| [$(basename "${mofaScriptRelativePath}")](${mofaScriptURL}) | \`${localOpLabel}\` | ${classification} | $(escapeForMarkdown "${note}") |"
@@ -409,8 +494,8 @@ function buildScriptCoverageSection() {
     for operationID in "${localOnlyOperations[@]}"; do
         note="${localOnlyReason[${operationID}]}"
         if ! scriptContainsOperation "${operationID}"; then
-            note="Expected local-only operation is missing from Microsoft-365-Reset.zsh."
-            addCandidateItem "${operationID}: expected local-only operation is missing from Microsoft-365-Reset.zsh"
+            note="Expected local-only operation is not fully wired through metadata, implementation, dispatch, and execution ordering."
+            addCandidateItem "${operationID}: expected local-only operation is not fully wired in Microsoft-365-Reset.zsh"
             classification="Candidate inclusion"
         else
             classification="Local-only operation"
@@ -508,40 +593,68 @@ function buildFeedComparisonSection() {
         note=""
         fallbackNote=""
 
+        if [[ -n "${localPrimary}" ]] && ! scriptContainsLiteral "${localPrimary}"; then
+            classification="Candidate inclusion"
+            note="Expected local primary repair URL is not present in Microsoft-365-Reset.zsh; report metadata may be stale."
+            addCandidateItem "${displayName}: expected local primary repair URL is not present in Microsoft-365-Reset.zsh"
+        fi
+
+        if [[ -n "${localFallback}" ]] && ! scriptContainsLiteral "${localFallback}"; then
+            classification="Candidate inclusion"
+            note="${note}${note:+ }Expected local fallback repair URL is not present in Microsoft-365-Reset.zsh; report metadata may be stale."
+            addCandidateItem "${displayName}: expected local fallback repair URL is not present in Microsoft-365-Reset.zsh"
+        fi
+
+        if [[ -n "${localApplicationID}" ]] && ! scriptContainsLiteral "${localApplicationID}"; then
+            classification="Candidate inclusion"
+            note="${note}${note:+ }Expected local application ID is not present in Microsoft-365-Reset.zsh; report metadata may be stale."
+            addCandidateItem "${displayName}: expected local application ID ${localApplicationID} is not present in Microsoft-365-Reset.zsh"
+        fi
+
+        if [[ -n "${localThreshold}" ]] && ! scriptContainsLiteral "${localThreshold}"; then
+            classification="Candidate inclusion"
+            note="${note}${note:+ }Expected local minimum-version threshold is not present in Microsoft-365-Reset.zsh; report metadata may be stale."
+            addCandidateItem "${displayName}: expected local minimum-version threshold ${localThreshold} is not present in Microsoft-365-Reset.zsh"
+        fi
+
         if [[ -z "${feedFullVersion}" ]]; then
-            classification="Skipped"
-            note="MOFA stable feed does not publish ${displayName} in macos_standalone_latest.json; local comparison was skipped."
+            if [[ "${classification}" == "Candidate inclusion" ]]; then
+                note="${note}${note:+ }MOFA stable feed does not publish ${displayName} in macos_standalone_latest.json; feed comparison was skipped."
+            else
+                classification="Skipped"
+                note="MOFA stable feed does not publish ${displayName} in macos_standalone_latest.json; local comparison was skipped."
+            fi
             appendReportLine "| ${displayName} | ${classification} | $(escapeForMarkdown "${note}") |"
             continue
         fi
 
         if [[ "${feedPrimaryURL}" != "${localPrimary}" ]]; then
             classification="Candidate inclusion"
-            note="Primary repair URL differs. Local: ${localPrimary}; MOFA stable feed: ${feedPrimaryURL}."
+            note="${note}${note:+ }Primary repair URL differs. Local: ${localPrimary}; MOFA stable feed: ${feedPrimaryURL}."
             addCandidateItem "${displayName}: primary repair URL differs from MOFA stable feed"
         else
-            note="Primary repair URL matches MOFA stable feed."
+            note="${note}${note:+ }Primary repair URL matches MOFA stable feed."
         fi
 
         if [[ -n "${localApplicationID}" && "${feedApplicationID}" != "${localApplicationID}" ]]; then
             classification="Candidate inclusion"
-            note="${note} Application ID differs. Local: ${localApplicationID}; MOFA stable feed: ${feedApplicationID}."
+            note="${note}${note:+ }Application ID differs. Local: ${localApplicationID}; MOFA stable feed: ${feedApplicationID}."
             addCandidateItem "${displayName}: application ID differs from MOFA stable feed"
         elif [[ -n "${localApplicationID}" ]]; then
-            note="${note} Application ID matches ${localApplicationID}."
+            note="${note}${note:+ }Application ID matches ${localApplicationID}."
         fi
 
         if [[ -n "${localFallback}" && -n "${feedAppOnlyURL}" && "${feedAppOnlyURL}" != "N/A" ]]; then
-            fallbackNote=" Local fallback repair URL remains hard-coded as ${localFallback}; MOFA stable feed publishes the app-only package as ${feedAppOnlyURL}."
-            note="${note}${fallbackNote}"
+            fallbackNote="Local fallback repair URL remains hard-coded as ${localFallback}; MOFA stable feed publishes the app-only package as ${feedAppOnlyURL}."
+            note="${note}${note:+ }${fallbackNote}"
         fi
 
         if [[ -n "${localThreshold}" ]]; then
             if is-at-least "${localThreshold}" "${feedFullVersion}"; then
-                note="${note} Current MOFA version ${feedFullVersion} remains above the local minimum threshold ${localThreshold}."
+                note="${note}${note:+ }Current MOFA version ${feedFullVersion} remains above the local minimum threshold ${localThreshold}."
             else
                 classification="Candidate inclusion"
-                note="${note} Current MOFA version ${feedFullVersion} is below the local minimum threshold ${localThreshold}."
+                note="${note}${note:+ }Current MOFA version ${feedFullVersion} is below the local minimum threshold ${localThreshold}."
                 addCandidateItem "${displayName}: current MOFA version ${feedFullVersion} is below local threshold ${localThreshold}"
             fi
         fi
@@ -577,6 +690,7 @@ function writeReport() {
         print -r -- "- Candidate inclusion items: ${candidateCount}"
         print -r -- "- Intentional divergences: ${intentionalCount}"
         print -r -- "- Local-only operations: ${localOnlyCount}"
+        print -r -- "- Scope: structural operation wiring and feed metadata; semantic parity still requires implementation review"
         print -r -- ""
 
         for line in "${reportLines[@]}"; do


### PR DESCRIPTION
- Reviewed [MOFA](https://github.com/cocopuff2u/MOFA) repo
    - Reclassified deferred app cleanup after repair as MOFA-aligned behavior and narrowed the documented Teams divergences
    - Ensured `reset_teams_force` installs current Teams when no app bundle exists
    - Hardened MOFA reporting to validate complete operation wiring and expected runtime metadata before reporting coverage
- Aligned the selection dialog icon and overlay icon with the intro dialog
- Pinned seven GitHub Actions to immutable commit SHAs, clearing all Semgrep findings